### PR TITLE
unpin environment

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,7 @@ name: voila-gallery-xstack
 channels:
   - conda-forge
 dependencies:
-  - voila=0.1.21
-  - xleaflet=0.11.1
-  - ipyleaflet=0.12.6
-  - xeus-cling=0.8.1
+  - voila
+  - xleaflet
+  - ipyleaflet
+  - xeus-cling


### PR DESCRIPTION
pinning a partial environment makes a broken env more likely than a completely unpinned env, as dependencies may be updated, while the packages themselves may not get the necessary fixes, even if they've been updated

this repo is currently failing builds on binder:

```
Encountered problems while solving.
Problem: package nbclassic-0.3.1-pyhd8ed1ab_1 requires jupyter_server >=1.8.0,<2.0.0, but none of the providers can be installed
```